### PR TITLE
Drop version from docker image

### DIFF
--- a/spring-cloud-lattice-sample/pom.xml
+++ b/spring-cloud-lattice-sample/pom.xml
@@ -46,7 +46,7 @@
 				<artifactId>docker-maven-plugin</artifactId>
 				<version>0.2.3</version>
 				<configuration>
-					<imageName>${docker.image.prefix}/${project.artifactId}:${project.version}</imageName>
+					<imageName>${docker.image.prefix}/${project.artifactId}</imageName>
 					<dockerDirectory>src/main/docker</dockerDirectory>
 					<resources>
 						<resource>


### PR DESCRIPTION
To make writing guides easier, its best if we drop the version number from the docker image and just let ist use latest. Otherwise, we will have to keep the guide up-to-date based on updates to this project.
